### PR TITLE
Add support for vinkla/hashids V12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	"require": {
 		"php": "~7.3||^8.0",
 		"illuminate/support": "^8.0||^9.0||^10.0||^11.0",
-		"vinkla/hashids": "~9.1||~10.0||^11.0"
+		"vinkla/hashids": "~9.1||~10.0||^11.0||^12.0"
 	},
 	"require-dev": {
 		"illuminate/database": "^8.0||^9.0||^10.0||^11.0",


### PR DESCRIPTION
[vinkla/hashids](https://packagist.org/packages/vinkla/hashids) v11 does not support Laravel 11, at least in terms of the composer dependency tree, which I think is preventing me from upgrading to Laravel 11. V12 does though.